### PR TITLE
optimizations for managing gearsets and Characters

### DIFF
--- a/HimbeertoniRaidTool/Configuration.cs
+++ b/HimbeertoniRaidTool/Configuration.cs
@@ -77,6 +77,7 @@ namespace HimbeertoniRaidTool
                         DataManagement.DataManager.Fill(RaidGroups);
                         RaidGroups = new();
                         Version = 3;
+                        Save();
                         break;
                     default:
                         throw new Exception("Unsupported Version of Configuration");

--- a/HimbeertoniRaidTool/Configuration.cs
+++ b/HimbeertoniRaidTool/Configuration.cs
@@ -1,9 +1,9 @@
-﻿using Dalamud.Configuration;
+﻿using System;
+using System.Collections.Generic;
+using Dalamud.Configuration;
 using Dalamud.Logging;
 using HimbeertoniRaidTool.Data;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using static HimbeertoniRaidTool.Data.AvailableClasses;
 
 namespace HimbeertoniRaidTool
@@ -13,7 +13,7 @@ namespace HimbeertoniRaidTool
     {
         [JsonIgnore]
         public bool FullyLoaded { get; private set; } = false;
-        private readonly int TargetVersion = 2;
+        private readonly int TargetVersion = 3;
         public int Version { get; set; } = 2;
         public Dictionary<AvailableClasses, string> DefaultBIS { get; set; } = new Dictionary<AvailableClasses, string>
         {
@@ -73,6 +73,11 @@ namespace HimbeertoniRaidTool
                         GroupInfo = null;
                         Version = 2;
                         break;
+                    case 2:
+                        DataManagement.DataManager.Fill(RaidGroups);
+                        RaidGroups = new();
+                        Version = 3;
+                        break;
                     default:
                         throw new Exception("Unsupported Version of Configuration");
                 }
@@ -104,9 +109,6 @@ namespace HimbeertoniRaidTool
                         }
                 );
             }
-            foreach (RaidGroup group in RaidGroups)
-                foreach (Player player in group.Players)
-                    player.MainChar.CleanUpClasses();
             FullyLoaded = true;
         }
     }

--- a/HimbeertoniRaidTool/Data/Character.cs
+++ b/HimbeertoniRaidTool/Data/Character.cs
@@ -1,7 +1,7 @@
-﻿using Lumina.Excel.GeneratedSheets;
-using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using Lumina.Excel.GeneratedSheets;
+using Newtonsoft.Json;
 
 namespace HimbeertoniRaidTool.Data
 {
@@ -24,11 +24,15 @@ namespace HimbeertoniRaidTool.Data
 
         [JsonIgnore]
         public bool Filled => Name != "";
-        public Character(string name = "") => Name = name;
+        public Character(string name = "", uint worldID = 0)
+        {
+            Name = name;
+            HomeWorldID = worldID;
+        }
 
         private PlayableClass AddClass(AvailableClasses ClassToAdd)
         {
-            PlayableClass toAdd = new(ClassToAdd);
+            PlayableClass toAdd = new(ClassToAdd, this);
             Classes.Add(toAdd);
             return toAdd;
         }

--- a/HimbeertoniRaidTool/Data/Character.cs
+++ b/HimbeertoniRaidTool/Data/Character.cs
@@ -16,7 +16,7 @@ namespace HimbeertoniRaidTool.Data
         public AvailableClasses MainClassType = AvailableClasses.AST;
         public PlayableClass MainClass => GetClass(MainClassType);
         [JsonProperty("WorldID")]
-        public uint HomeWorldID { get; private set; }
+        public uint HomeWorldID;
         public World? HomeWorld
         {
             get => HomeWorldID > 0 ? Services.DataManager.GetExcelSheet<World>()?.GetRow(HomeWorldID) : null;

--- a/HimbeertoniRaidTool/Data/Character.cs
+++ b/HimbeertoniRaidTool/Data/Character.cs
@@ -5,25 +5,25 @@ using Newtonsoft.Json;
 
 namespace HimbeertoniRaidTool.Data
 {
-    [Serializable]
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public class Character : IEquatable<Character>
     {
+        [JsonProperty("Classes")]
         public List<PlayableClass> Classes = new();
+        [JsonProperty("Name")]
         public string Name = "";
+        [JsonProperty("MainClassType")]
         public AvailableClasses MainClassType = AvailableClasses.AST;
-        [JsonIgnore]
         public PlayableClass MainClass => GetClass(MainClassType);
         [JsonProperty("WorldID")]
         public uint HomeWorldID { get; private set; }
-        [JsonIgnore]
         public World? HomeWorld
         {
             get => HomeWorldID > 0 ? Services.DataManager.GetExcelSheet<World>()?.GetRow(HomeWorldID) : null;
             set => HomeWorldID = value?.RowId ?? 0;
         }
-
-        [JsonIgnore]
         public bool Filled => Name != "";
+        [JsonConstructor]
         public Character(string name = "", uint worldID = 0)
         {
             Name = name;

--- a/HimbeertoniRaidTool/Data/EtroConnector.cs
+++ b/HimbeertoniRaidTool/Data/EtroConnector.cs
@@ -1,8 +1,8 @@
-﻿using Dalamud.Logging;
-using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using Dalamud.Logging;
+using Newtonsoft.Json;
 
 namespace HimbeertoniRaidTool.Data
 {
@@ -95,13 +95,12 @@ namespace HimbeertoniRaidTool.Data
             {
                 set[slot] = new(id);
                 string idString = id.ToString() + (slot == GearSetSlot.Ring1 ? "L" : slot == GearSetSlot.Ring2 ? "R" : "");
-                if (etroSet!.materia.TryGetValue(idString, out Dictionary<uint, uint>? materia))
+                if (etroSet!.materia?.TryGetValue(idString, out Dictionary<uint, uint>? materia) ?? false)
                     foreach (uint matId in materia.Values)
                         set[slot].Materia.Add(new(MateriaCache.GetValueOrDefault<uint, (MateriaCategory, byte)>(matId, (0, 0))));
             }
         }
     }
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Benennungsstile", Justification = "class is maintained by 3rd party")]
     class EtroGearSet
     {
 
@@ -109,7 +108,7 @@ namespace HimbeertoniRaidTool.Data
         public string? jobAbbrev { get; set; }
         public string? name { get; set; }
         public DateTime lastUpdate { get; set; }
-        public Dictionary<string, Dictionary<uint, uint>> materia { get; set; }
+        public Dictionary<string, Dictionary<uint, uint>>? materia { get; set; }
         public uint weapon { get; set; }
         public uint head { get; set; }
         public uint body { get; set; }

--- a/HimbeertoniRaidTool/Data/GearItem.cs
+++ b/HimbeertoniRaidTool/Data/GearItem.cs
@@ -49,10 +49,24 @@ namespace HimbeertoniRaidTool.Data
             if (ReferenceEquals(this, other)) return true;
             if (ID != other.ID) return false;
             if (Materia.Count != other.Materia.Count) return false;
-            for (int i = 0; i < Materia.Count; i++)
+            var cnt = new Dictionary<HrtMateria, int>();
+            foreach (HrtMateria s in Materia)
             {
-                if (!Materia[i].Equals(other.Materia[i])) return false;
+                if (cnt.ContainsKey(s))
+                    cnt[s]++;
+                else
+                    cnt.Add(s, 1);
             }
+            foreach (HrtMateria s in other.Materia)
+            {
+                if (cnt.ContainsKey(s))
+                    cnt[s]--;
+                else
+                    return false;
+            }
+            foreach (int s in cnt.Values)
+                if (s != 0)
+                    return false;
             return true;
         }
     }

--- a/HimbeertoniRaidTool/Data/GearItem.cs
+++ b/HimbeertoniRaidTool/Data/GearItem.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 
 namespace HimbeertoniRaidTool.Data
 {
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public class GearItem : HrtItem
     {
         private static KeyContainsDictionary<GearSource> SourceDic => CuratedData.GearSourceDictionary;
@@ -15,7 +16,7 @@ namespace HimbeertoniRaidTool.Data
         public GearSetSlot Slot => SlotOverride ?? (Item.EquipSlotCategory.Value?.ToSlot()) ?? GearSetSlot.None;
         [JsonIgnore]
         public GearSource Source => _ID > 0 ? SourceDic.GetValueOrDefault(Name, GearSource.undefined) : GearSource.undefined;
-
+        [JsonProperty("Materia")]
         public List<HrtMateria> Materia = new();
         [JsonIgnore]
         public uint ItemLevel => (Item.LevelItem is null) ? 0 : Item.LevelItem.Row;
@@ -42,6 +43,7 @@ namespace HimbeertoniRaidTool.Data
             return result;
         }
         public GearItem() : base() { }
+        [JsonConstructor]
         public GearItem(uint id) : base(id) { }
         public bool Equals(GearItem other)
         {
@@ -70,19 +72,16 @@ namespace HimbeertoniRaidTool.Data
             return true;
         }
     }
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public class HrtItem
     {
         protected uint _ID;
+        [JsonProperty("ID")]
         public virtual uint ID { get => _ID; set { _ID = value; } }
-        [JsonIgnore]
         public TextureWrap? Icon => Services.DataManager.GetImGuiTextureIcon(Item.Icon);
-        [JsonIgnore]
         public Item Item => Sheet?.GetRow(ID) ?? new Item();
-        [JsonIgnore]
         public string Name => ID > 0 ? Item.Name.RawString : "";
-        [JsonIgnore]
         public bool Filled => ID > 0 && Name.Length > 0;
-        [JsonIgnore]
         public bool Valid => ID > 0;
 
         protected static ExcelSheet<Item>? Sheet => Services.DataManager.Excel.GetSheet<Item>();
@@ -100,19 +99,19 @@ namespace HimbeertoniRaidTool.Data
         }
         public override int GetHashCode() => ID.GetHashCode();
     }
-
+    [JsonObject(MemberSerialization.OptIn)]
     public class HrtMateria : HrtItem
     {
+        [JsonProperty("Category")]
         public MateriaCategory Category;
+        [JsonProperty("MateriaLevel")]
         public byte MateriaLevel;
-        [JsonIgnore]
         private ExcelSheet<Materia> MateriaSheet => Services.DataManager.Excel.GetSheet<Materia>()!;
-        [JsonIgnore]
         public override uint ID => Category != MateriaCategory.None ? Materia?.Item[MateriaLevel].Row ?? 0 : 0;
-        [JsonIgnore]
         public Materia? Materia => MateriaSheet.GetRow((ushort)Category);
         public HrtMateria() : this(0, 0) { }
         public HrtMateria((MateriaCategory cat, byte lvl) mat) : this(mat.cat, mat.lvl) { }
+        [JsonConstructor]
         public HrtMateria(MateriaCategory cat, byte lvl) => (Category, MateriaLevel) = (cat, lvl);
         public int GetStat(StatType type)
         {

--- a/HimbeertoniRaidTool/Data/GearSet.cs
+++ b/HimbeertoniRaidTool/Data/GearSet.cs
@@ -3,30 +3,46 @@ using Newtonsoft.Json;
 
 namespace HimbeertoniRaidTool.Data
 {
+    [JsonObject(MemberSerialization.OptIn)]
     public class GearSet
     {
+        [JsonProperty("TimeStamp")]
         public DateTime? TimeStamp;
+        [JsonProperty("EtroID")]
         public string EtroID = "";
+        [JsonProperty("HrtID")]
         public string HrtID = "";
+        [JsonProperty("Name")]
         public string Name = "";
+        [JsonProperty("ManagedBy")]
         public GearSetManager ManagedBy;
         private const int NumSlots = 12;
         private readonly GearItem[] Items = new GearItem[NumSlots];
+        [JsonProperty]
         public GearItem MainHand { get => Items[0]; set => Items[0] = value; }
+        [JsonProperty]
         public GearItem Head { get => Items[1]; set => Items[1] = value; }
+        [JsonProperty]
         public GearItem Body { get => Items[2]; set => Items[2] = value; }
+        [JsonProperty]
         public GearItem Hands { get => Items[3]; set => Items[3] = value; }
+        [JsonProperty]
         public GearItem Legs { get => Items[4]; set => Items[4] = value; }
+        [JsonProperty]
         public GearItem Feet { get => Items[5]; set => Items[5] = value; }
+        [JsonProperty]
         public GearItem Ear { get => Items[6]; set => Items[6] = value; }
+        [JsonProperty]
         public GearItem Neck { get => Items[7]; set => Items[7] = value; }
+        [JsonProperty]
         public GearItem Wrist { get => Items[8]; set => Items[8] = value; }
+        [JsonProperty]
         public GearItem Ring1 { get => Items[9]; set => Items[9] = value; }
+        [JsonProperty]
         public GearItem Ring2 { get => Items[10]; set => Items[10] = value; }
+        [JsonProperty]
         public GearItem OffHand { get => Items[11]; set => Items[11] = value; }
-        [JsonIgnore]
         public bool IsEmpty => Array.TrueForAll(Items, x => x.ID == 0);
-        [JsonIgnore]
         public int ItemLevel
         {
             get
@@ -64,7 +80,6 @@ namespace HimbeertoniRaidTool.Data
                 Items[i] = new(0);
             }
         }
-        [JsonIgnore]
         public GearItem this[GearSetSlot slot]
         {
             get => Items[ToIndex(slot)];

--- a/HimbeertoniRaidTool/Data/GearSet.cs
+++ b/HimbeertoniRaidTool/Data/GearSet.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace HimbeertoniRaidTool.Data
 {
@@ -7,6 +7,7 @@ namespace HimbeertoniRaidTool.Data
     {
         public DateTime? TimeStamp;
         public string EtroID = "";
+        public string HrtID = "";
         public string Name = "";
         public GearSetManager ManagedBy;
         private const int NumSlots = 12;
@@ -42,9 +43,18 @@ namespace HimbeertoniRaidTool.Data
 
             }
         }
-        public GearSet(GearSetManager manager = GearSetManager.HRT)
+        [JsonConstructor]
+        public GearSet()
+        {
+            ManagedBy = GearSetManager.HRT;
+            Clear();
+        }
+        public GearSet(GearSetManager manager, Character c, AvailableClasses ac, string name = "HrtCurrent")
         {
             ManagedBy = manager;
+            Name = name;
+            if (ManagedBy == GearSetManager.HRT)
+                HrtID = GenerateID(c, ac, this);
             Clear();
         }
         public void Clear()
@@ -84,6 +94,25 @@ namespace HimbeertoniRaidTool.Data
                 GearSetSlot.Ring2 => 10,
                 _ => throw new IndexOutOfRangeException("GearSlot" + slot.ToString() + "does not exist"),
             };
+        }
+
+        internal void CopyFrom(GearSet gearSet)
+        {
+            TimeStamp = gearSet.TimeStamp;
+            EtroID = gearSet.EtroID;
+            HrtID = gearSet.HrtID;
+            Name = gearSet.Name;
+            ManagedBy = gearSet.ManagedBy;
+            gearSet.Items.CopyTo(Items, 0);
+        }
+
+        public static string GenerateID(Character c, AvailableClasses ac, GearSet g)
+        {
+            string result = "";
+            result += string.Format("{0:X}-{1:X}-{2}-{3:X}", (c.HomeWorld?.Name ?? "").GetHashCode(), c.Name.GetHashCode(), ac, g.Name.GetHashCode());
+
+            return result;
+
         }
     }
 }

--- a/HimbeertoniRaidTool/Data/GearSet.cs
+++ b/HimbeertoniRaidTool/Data/GearSet.cs
@@ -120,11 +120,11 @@ namespace HimbeertoniRaidTool.Data
             ManagedBy = gearSet.ManagedBy;
             gearSet.Items.CopyTo(Items, 0);
         }
-
+        public void UpdateID(Character c, AvailableClasses ac) => HrtID = GenerateID(c, ac, this);
         public static string GenerateID(Character c, AvailableClasses ac, GearSet g)
         {
             string result = "";
-            result += string.Format("{0:X}-{1:X}-{2}-{3:X}", (c.HomeWorld?.Name ?? "").GetHashCode(), c.Name.GetHashCode(), ac, g.Name.GetHashCode());
+            result += string.Format("{0:X}-{1:X}-{2}-{3:X}", c.HomeWorldID, c.Name.ConsistentHash(), ac, g.Name.ConsistentHash());
 
             return result;
 

--- a/HimbeertoniRaidTool/Data/LootRuling.cs
+++ b/HimbeertoniRaidTool/Data/LootRuling.cs
@@ -1,13 +1,13 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using static Dalamud.Localization;
 
 namespace HimbeertoniRaidTool.Data
 {
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public class LootRuling
     {
-        [JsonIgnore]
         public static List<LootRule> PossibleRules
         {
             get
@@ -18,7 +18,9 @@ namespace HimbeertoniRaidTool.Data
                 return result;
             }
         }
+        [JsonProperty("RuleSet")]
         public List<LootRule> RuleSet = new();
+        [JsonProperty("StrictRooling")]
         public bool StrictRooling = false;
 
         public List<(Player, string)> Evaluate(RaidGroup group, GearSetSlot slot, List<Player>? excluded = null)
@@ -91,10 +93,11 @@ namespace HimbeertoniRaidTool.Data
             }
         }
     }
+    [JsonObject(MemberSerialization.OptIn)]
     public class LootRule
     {
+        [JsonProperty("Rule")]
         public LootRuleEnum? Rule;
-        [JsonIgnore]
         public Func<Player, Player, GearSetSlot, bool, int> Compare
         {
             get
@@ -141,7 +144,7 @@ namespace HimbeertoniRaidTool.Data
             return ((LootRule)obj).Rule.Equals(Rule);
         }
 
-
+        [JsonConstructor]
         public LootRule(LootRuleEnum? rule = null) => Rule = rule;
 
         public override int GetHashCode() => Rule.GetHashCode();

--- a/HimbeertoniRaidTool/Data/PlayableClass.cs
+++ b/HimbeertoniRaidTool/Data/PlayableClass.cs
@@ -3,8 +3,17 @@ using static HimbeertoniRaidTool.DataManagement.DataManager;
 
 namespace HimbeertoniRaidTool.Data
 {
+    [JsonObject(MemberSerialization.OptIn)]
     public class PlayableClass
     {
+        [JsonProperty("ClassType")]
+        public AvailableClasses ClassType;
+        [JsonProperty("Level")]
+        public int Level = 0;
+        [JsonProperty("Gear")]
+        public GearSet Gear;
+        [JsonProperty("BIS")]
+        public GearSet BIS;
         [JsonConstructor]
         public PlayableClass(AvailableClasses classType)
         {
@@ -20,21 +29,12 @@ namespace HimbeertoniRaidTool.Data
             BIS = new(GearSetManager.HRT, c, ClassType, "BIS");
             GetManagedGearSet(ref BIS);
         }
-        public AvailableClasses ClassType;
-        public int Level = 0;
-        public GearSet Gear;
-        public GearSet BIS;
-
-
-        [JsonIgnore]
         public bool IsEmpty => Level == 0 && Gear.IsEmpty && BIS.IsEmpty;
-
         public void ManageGear()
         {
             GetManagedGearSet(ref Gear);
             GetManagedGearSet(ref BIS);
         }
-
         public bool Equals(PlayableClass? other)
         {
             if (other == null)

--- a/HimbeertoniRaidTool/Data/PlayableClass.cs
+++ b/HimbeertoniRaidTool/Data/PlayableClass.cs
@@ -1,21 +1,39 @@
 ﻿using Newtonsoft.Json;
+using static HimbeertoniRaidTool.DataManagement.DataManager;
 
 namespace HimbeertoniRaidTool.Data
 {
     public class PlayableClass
     {
-        public PlayableClass(AvailableClasses ClassNameArg)
+        [JsonConstructor]
+        public PlayableClass(AvailableClasses classType)
+        {
+            ClassType = classType;
+            Gear = new();
+            BIS = new();
+        }
+        public PlayableClass(AvailableClasses ClassNameArg, Character c)
         {
             ClassType = ClassNameArg;
+            Gear = new(GearSetManager.HRT, c, ClassType);
+            GetManagedGearSet(ref Gear);
+            BIS = new(GearSetManager.HRT, c, ClassType, "BIS");
+            GetManagedGearSet(ref BIS);
         }
         public AvailableClasses ClassType;
         public int Level = 0;
-        public GearSet Gear = new(GearSetManager.HRT);
-        public GearSet BIS = new(GearSetManager.Etro);
+        public GearSet Gear;
+        public GearSet BIS;
+
 
         [JsonIgnore]
         public bool IsEmpty => Level == 0 && Gear.IsEmpty && BIS.IsEmpty;
 
+        public void ManageGear()
+        {
+            GetManagedGearSet(ref Gear);
+            GetManagedGearSet(ref BIS);
+        }
 
         public bool Equals(PlayableClass? other)
         {

--- a/HimbeertoniRaidTool/Data/Player.cs
+++ b/HimbeertoniRaidTool/Data/Player.cs
@@ -1,18 +1,19 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace HimbeertoniRaidTool.Data
 {
+    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public class Player : IComparable<Player>
     {
+        [JsonProperty("NickName")]
         public string NickName = "";
-        [JsonIgnore]
-        public bool Filled => NickName != "";
-
+        [JsonProperty("Pos")]
         public PositionInRaidGroup Pos;
+        [JsonProperty("Chars")]
         public List<Character> Chars { get; set; } = new();
-        [JsonIgnore]
+        public bool Filled => NickName != "";
         public Character MainChar
         {
             get
@@ -27,11 +28,10 @@ namespace HimbeertoniRaidTool.Data
                 Chars.Insert(0, value);
             }
         }
-        [JsonIgnore]
         public GearSet Gear => MainChar.MainClass.Gear;
-        [JsonIgnore]
         public GearSet BIS => MainChar.MainClass.BIS;
         public Player() { }
+        [JsonConstructor]
         public Player(PositionInRaidGroup pos) => Pos = pos;
         internal void Reset()
         {
@@ -41,8 +41,8 @@ namespace HimbeertoniRaidTool.Data
         public int CompareTo(Player? other)
         {
             if (other == null)
-                return Int32.MaxValue;
-            return this.Pos - other.Pos;
+                return int.MaxValue;
+            return Pos - other.Pos;
         }
 
 

--- a/HimbeertoniRaidTool/Data/RaidGroup.cs
+++ b/HimbeertoniRaidTool/Data/RaidGroup.cs
@@ -3,22 +3,32 @@ using Newtonsoft.Json;
 
 namespace HimbeertoniRaidTool.Data
 {
+    [JsonObject(MemberSerialization.OptIn)]
     public class RaidGroup
     {
+        [JsonProperty("TimeStamp")]
         public DateTime TimeStamp;
+        [JsonProperty("Name")]
         public string Name;
         private readonly Player[] _Players;
+        [JsonProperty("Type")]
         public GroupType Type;
-
+        [JsonProperty]
         public Player Tank1 { get => _Players[0]; set => _Players[0] = value; }
+        [JsonProperty]
         public Player Tank2 { get => _Players[1]; set => _Players[1] = value; }
+        [JsonProperty]
         public Player Heal1 { get => _Players[2]; set => _Players[2] = value; }
+        [JsonProperty]
         public Player Heal2 { get => _Players[3]; set => _Players[3] = value; }
+        [JsonProperty]
         public Player Melee1 { get => _Players[4]; set => _Players[4] = value; }
+        [JsonProperty]
         public Player Melee2 { get => _Players[5]; set => _Players[5] = value; }
+        [JsonProperty]
         public Player Ranged { get => _Players[6]; set => _Players[6] = value; }
+        [JsonProperty]
         public Player Caster { get => _Players[7]; set => _Players[7] = value; }
-        [JsonIgnore]
         public Player[] Players => Type switch
         {
             GroupType.Solo => new[] { _Players[0] },
@@ -33,6 +43,7 @@ namespace HimbeertoniRaidTool.Data
             GroupType.Raid => 8,
             _ => throw new NotImplementedException(),
         };
+        [JsonConstructor]
         public RaidGroup(string name = "", GroupType type = GroupType.Raid)
         {
             Type = type;
@@ -63,12 +74,15 @@ namespace HimbeertoniRaidTool.Data
             return null;
         }
     }
+    [JsonObject(MemberSerialization.OptIn)]
     public class Alliance
     {
+        [JsonProperty("Name")]
         public string Name { get; set; }
         public DateTime TimeStamp { get; set; }
+        [JsonProperty("Groups")]
         public RaidGroup[] RaidGroups { get; set; }
-
+        [JsonConstructor]
         public Alliance(string name = "")
         {
             Name = name;

--- a/HimbeertoniRaidTool/Data/RaidGroup.cs
+++ b/HimbeertoniRaidTool/Data/RaidGroup.cs
@@ -1,6 +1,5 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace HimbeertoniRaidTool.Data
 {
@@ -20,11 +19,18 @@ namespace HimbeertoniRaidTool.Data
         public Player Ranged { get => _Players[6]; set => _Players[6] = value; }
         public Player Caster { get => _Players[7]; set => _Players[7] = value; }
         [JsonIgnore]
-        public IEnumerable<Player> Players => Type switch
+        public Player[] Players => Type switch
         {
             GroupType.Solo => new[] { _Players[0] },
             GroupType.Group => new[] { _Players[0], _Players[2], _Players[4], _Players[6], },
             GroupType.Raid => _Players,
+            _ => throw new NotImplementedException(),
+        };
+        public int Count => Type switch
+        {
+            GroupType.Solo => 1,
+            GroupType.Group => 4,
+            GroupType.Raid => 8,
             _ => throw new NotImplementedException(),
         };
         public RaidGroup(string name = "", GroupType type = GroupType.Raid)

--- a/HimbeertoniRaidTool/DataManagement/CharacterDB.cs
+++ b/HimbeertoniRaidTool/DataManagement/CharacterDB.cs
@@ -25,14 +25,20 @@ namespace HimbeertoniRaidTool.DataManagement
                 DataManager.JsonSerializerSettings) ?? new();
             DataManager.JsonSerializerSettings.Converters.Remove(conv);
         }
-        internal void AddOrGetCharacter(uint worldID, string name, ref Character c)
+        internal void AddOrGetCharacter(ref Character c)
         {
-            if (!CharDB.ContainsKey(worldID))
-                CharDB.Add(worldID, new Dictionary<string, Character>());
-            if (!CharDB[worldID].ContainsKey(name))
-                CharDB[worldID].Add(name, c);
-            if (CharDB[worldID].TryGetValue(name, out Character? c2))
+            if (!CharDB.ContainsKey(c.HomeWorldID))
+                CharDB.Add(c.HomeWorldID, new Dictionary<string, Character>());
+            if (!CharDB[c.HomeWorldID].ContainsKey(c.Name))
+                CharDB[c.HomeWorldID].Add(c.Name, c);
+            if (CharDB[c.HomeWorldID].TryGetValue(c.Name, out Character? c2))
                 c = c2;
+        }
+        internal void UpdateIndex(uint oldWorld, string oldName, ref Character c)
+        {
+            if (CharDB.ContainsKey(oldWorld))
+                CharDB[oldWorld].Remove(oldName);
+            AddOrGetCharacter(ref c);
         }
         internal void Save()
         {
@@ -43,6 +49,7 @@ namespace HimbeertoniRaidTool.DataManagement
                 JsonConvert.SerializeObject(CharDB, DataManager.JsonSerializerSettings));
             DataManager.JsonSerializerSettings.Converters.Remove(conv);
         }
+
     }
     public struct CharacterDBIndex
     {

--- a/HimbeertoniRaidTool/DataManagement/CharacterDB.cs
+++ b/HimbeertoniRaidTool/DataManagement/CharacterDB.cs
@@ -25,6 +25,9 @@ namespace HimbeertoniRaidTool.DataManagement
                 DataManager.JsonSerializerSettings) ?? new();
             DataManager.JsonSerializerSettings.Converters.Remove(conv);
         }
+        internal bool Exists(uint worldID, string name) =>
+            CharDB.ContainsKey(worldID) && CharDB[worldID].ContainsKey(name);
+
         internal void AddOrGetCharacter(ref Character c)
         {
             if (!CharDB.ContainsKey(c.HomeWorldID))

--- a/HimbeertoniRaidTool/DataManagement/CharacterDB.cs
+++ b/HimbeertoniRaidTool/DataManagement/CharacterDB.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using HimbeertoniRaidTool.Data;
+using Lumina.Excel.GeneratedSheets;
+using Newtonsoft.Json;
+
+namespace HimbeertoniRaidTool.DataManagement
+{
+    internal class CharacterDB
+    {
+        private readonly Dictionary<uint, Dictionary<string, Character>> CharDB;
+        private readonly FileInfo CharDBJsonFile;
+
+        internal CharacterDB(DirectoryInfo loadDir, bool reset)
+        {
+            var conv = new GearSetReferenceConverter();
+            DataManager.JsonSerializerSettings.Converters.Add(conv);
+
+            CharDBJsonFile = new FileInfo(loadDir.FullName + "\\CharacterDB.json");
+            if (!CharDBJsonFile.Exists)
+                CharDBJsonFile.Create().Close();
+            CharDB = JsonConvert.DeserializeObject<Dictionary<uint, Dictionary<string, Character>>>(
+                reset ? "" : CharDBJsonFile.OpenText().ReadToEnd(),
+                DataManager.JsonSerializerSettings) ?? new();
+            DataManager.JsonSerializerSettings.Converters.Remove(conv);
+        }
+        internal void AddOrGetCharacter(uint worldID, string name, ref Character c)
+        {
+            if (!CharDB.ContainsKey(worldID))
+                CharDB.Add(worldID, new Dictionary<string, Character>());
+            if (!CharDB[worldID].ContainsKey(name))
+                CharDB[worldID].Add(name, c);
+            if (CharDB[worldID].TryGetValue(name, out Character? c2))
+                c = c2;
+        }
+        internal void Save()
+        {
+            var conv = new GearSetReferenceConverter();
+
+            DataManager.JsonSerializerSettings.Converters.Add(conv);
+            File.WriteAllText(CharDBJsonFile.FullName,
+                JsonConvert.SerializeObject(CharDB, DataManager.JsonSerializerSettings));
+            DataManager.JsonSerializerSettings.Converters.Remove(conv);
+        }
+    }
+    public struct CharacterDBIndex
+    {
+        [JsonConstructor]
+        public CharacterDBIndex(uint worldID, string name)
+        {
+            WorldID = worldID;
+            Name = name;
+        }
+        [JsonProperty]
+        public uint WorldID;
+        [JsonProperty]
+        public string Name;
+    }
+}

--- a/HimbeertoniRaidTool/DataManagement/CharacterReferenceConverter.cs
+++ b/HimbeertoniRaidTool/DataManagement/CharacterReferenceConverter.cs
@@ -30,11 +30,12 @@ namespace HimbeertoniRaidTool.DataManagement
                 return null;
             JObject jt = JObject.Load(reader);
 
-            CharacterReference? cRef = jt.ContainsKey("WorldID") && jt.ContainsKey("Name") ? new((uint)(jt["WorldID"] ?? 0), (string?)jt["Name"] ?? "") : null;
+            CharacterReference? cRef = jt.ContainsKey("WorldID") && jt.ContainsKey("Name") ?
+                new((uint)(jt["WorldID"] ?? 0), (string?)jt["Name"] ?? "") : null;
             if (cRef == null)
                 return null;
             Character result = new(cRef.Name, cRef.HomeWorldID);
-            DataManager.CharacterDB.AddOrGetCharacter(cRef.HomeWorldID, cRef.Name, ref result);
+            DataManager.CharacterDB.AddOrGetCharacter(ref result);
             return result;
         }
     }

--- a/HimbeertoniRaidTool/DataManagement/CharacterReferenceConverter.cs
+++ b/HimbeertoniRaidTool/DataManagement/CharacterReferenceConverter.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HimbeertoniRaidTool.Data;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace HimbeertoniRaidTool.DataManagement
+{
+    internal class CharacterReferenceConverter : JsonConverter<Character>
+    {
+        public override void WriteJson(JsonWriter writer, Character? value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            CharacterReference cRef = new(value);
+            serializer.Serialize(writer, cRef, typeof(CharacterReference));
+        }
+
+        public override Character? ReadJson(JsonReader reader, Type objectType, Character? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+            if (objectType != typeof(Character))
+                return null;
+            JObject jt = JObject.Load(reader);
+
+            CharacterReference? cRef = jt.ContainsKey("WorldID") && jt.ContainsKey("Name") ? new((uint)(jt["WorldID"] ?? 0), (string?)jt["Name"] ?? "") : null;
+            if (cRef == null)
+                return null;
+            Character result = new(cRef.Name, cRef.HomeWorldID);
+            DataManager.CharacterDB.AddOrGetCharacter(cRef.HomeWorldID, cRef.Name, ref result);
+            return result;
+        }
+    }
+    public class CharacterReference
+    {
+        [JsonProperty("WorldID")]
+        public uint HomeWorldID;
+        [JsonProperty("Name")]
+        public string Name;
+        [JsonConstructor]
+        public CharacterReference(uint homeWorldID, string name)
+        {
+            HomeWorldID = homeWorldID;
+            Name = name;
+        }
+        public CharacterReference(Character c)
+        {
+            HomeWorldID = c.HomeWorldID;
+            Name = c.Name;
+        }
+    }
+}

--- a/HimbeertoniRaidTool/DataManagement/DataManager.cs
+++ b/HimbeertoniRaidTool/DataManagement/DataManager.cs
@@ -43,6 +43,8 @@ namespace HimbeertoniRaidTool.DataManagement
             JsonSerializerSettings.Converters.Remove(crc);
             Initialized = true;
         }
+        public static bool CharacterExists(uint worldID, string name) =>
+            CharacterDB.Exists(worldID, name);
         public static void GetManagedGearSet(ref GearSet gs)
         {
             if (Initialized)

--- a/HimbeertoniRaidTool/DataManagement/DataManager.cs
+++ b/HimbeertoniRaidTool/DataManagement/DataManager.cs
@@ -51,7 +51,23 @@ namespace HimbeertoniRaidTool.DataManagement
         public static void GetManagedCharacter(ref Character c)
         {
             if (Initialized)
-                CharacterDB.AddOrGetCharacter(c.HomeWorldID, c.Name, ref c);
+                CharacterDB.AddOrGetCharacter(ref c);
+        }
+        public static void RearrangeCharacter(uint oldWorld, string oldName, ref Character c)
+        {
+            if (!Initialized)
+                return;
+            CharacterDB.UpdateIndex(oldWorld, oldName, ref c);
+            for (int i = 0; i < c.Classes.Count; i++)
+            {
+                string oldID = c.Classes[i].Gear.HrtID;
+                c.Classes[i].Gear.UpdateID(c, c.Classes[i].ClassType);
+                RearrangeGearSet(oldID, ref c.Classes[i].Gear);
+            }
+        }
+        public static void RearrangeGearSet(string oldID, ref GearSet gs)
+        {
+            GearDB.UpdateIndex(oldID, ref gs);
         }
         public static void Fill(List<RaidGroup> rg)
         {

--- a/HimbeertoniRaidTool/DataManagement/DataManager.cs
+++ b/HimbeertoniRaidTool/DataManagement/DataManager.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using HimbeertoniRaidTool.Data;
+using Newtonsoft.Json;
+
+namespace HimbeertoniRaidTool.DataManagement
+{
+    public static class DataManager
+    {
+        private static bool Initialized;
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        internal static GearDB GearDB;
+        internal static CharacterDB CharacterDB;
+        private static List<RaidGroup> _Groups;
+        private static FileInfo RaidGRoupJsonFile;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public static List<RaidGroup> Groups => _Groups;
+        internal static JsonSerializerSettings JsonSerializerSettings = new()
+        {
+            Formatting = Formatting.Indented,
+            TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
+            TypeNameHandling = TypeNameHandling.None,
+
+        };
+
+        public static void Init(bool reset = false)
+        {
+            var dir = Services.PluginInterface.ConfigDirectory;
+            if (!dir.Exists)
+                dir.Create();
+
+            GearDB = new(dir, reset);
+            CharacterDB = new(dir, reset);
+            RaidGRoupJsonFile = new FileInfo(dir.FullName + "\\RaidGroups.json");
+            if (!RaidGRoupJsonFile.Exists)
+                RaidGRoupJsonFile.Create().Close();
+            var crc = new CharacterReferenceConverter();
+            JsonSerializerSettings.Converters.Add(crc);
+            _Groups = JsonConvert.DeserializeObject<List<RaidGroup>>(
+                reset ? "" : RaidGRoupJsonFile.OpenText().ReadToEnd(),
+                JsonSerializerSettings) ?? new();
+            JsonSerializerSettings.Converters.Remove(crc);
+            Initialized = true;
+        }
+        public static void GetManagedGearSet(ref GearSet gs)
+        {
+            if (Initialized)
+                GearDB.AddOrGetSet(ref gs);
+        }
+        public static void GetManagedCharacter(ref Character c)
+        {
+            if (Initialized)
+                CharacterDB.AddOrGetCharacter(c.HomeWorldID, c.Name, ref c);
+        }
+        public static void Fill(List<RaidGroup> rg)
+        {
+            Init(true);
+            _Groups = rg;
+            for (int i = 0; i < _Groups.Count; i++)
+            {
+                for (int j = 0; j < _Groups[i].Players.Length; j++)
+                {
+                    for (int k = 0; k < _Groups[i].Players[j].Chars.Count; k++)
+                    {
+                        Character c = _Groups[i].Players[j].Chars[k];
+                        GetManagedCharacter(ref c);
+                        _Groups[i].Players[j].Chars[k] = c;
+                        for (int l = 0; l < c.Classes.Count; l++)
+                        {
+                            PlayableClass pc = c.Classes[l];
+                            pc.Gear.Name = "HrtCurrent";
+                            pc.Gear.HrtID = GearSet.GenerateID(c, pc.ClassType, pc.Gear);
+                            pc.BIS.ManagedBy = GearSetManager.Etro;
+                            pc.ManageGear();
+                        }
+                    }
+                }
+            }
+        }
+        public static void Save()
+        {
+            if (!Initialized)
+                return;
+            GearDB.Save();
+            CharacterDB.Save();
+            //TODO: RaidGroups
+            var crc = new CharacterReferenceConverter();
+            JsonSerializerSettings.Converters.Add(crc);
+            File.WriteAllText(RaidGRoupJsonFile.FullName,
+                JsonConvert.SerializeObject(_Groups, JsonSerializerSettings));
+            JsonSerializerSettings.Converters.Remove(crc);
+
+        }
+    }
+}

--- a/HimbeertoniRaidTool/DataManagement/GearDB.cs
+++ b/HimbeertoniRaidTool/DataManagement/GearDB.cs
@@ -49,7 +49,21 @@ namespace HimbeertoniRaidTool.DataManagement
                     gearSet = result;
             }
         }
-
+        internal void UpdateIndex(string oldID, ref GearSet gs)
+        {
+            if (gs.ManagedBy == GearSetManager.HRT)
+            {
+                if (HrtGearDB.ContainsKey(oldID))
+                    HrtGearDB.Remove(oldID);
+                AddOrGetSet(ref gs);
+            }
+            else if (gs.ManagedBy == GearSetManager.Etro)
+            {
+                if (EtroGearDB.ContainsKey(oldID))
+                    EtroGearDB.Remove(oldID);
+                AddOrGetSet(ref gs);
+            }
+        }
         internal void Save()
         {
             File.WriteAllText(HrtDBJsonFile.FullName,

--- a/HimbeertoniRaidTool/DataManagement/GearDB.cs
+++ b/HimbeertoniRaidTool/DataManagement/GearDB.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using HimbeertoniRaidTool.Data;
+using Newtonsoft.Json;
+
+namespace HimbeertoniRaidTool.DataManagement
+{
+    internal class GearDB
+    {
+        private readonly Dictionary<string, GearSet> HrtGearDB;
+        private readonly Dictionary<string, GearSet> EtroGearDB;
+        private readonly FileInfo HrtDBJsonFile;
+        private readonly FileInfo EtroDBJsonFile;
+        internal GearDB(DirectoryInfo loadDir, bool reset)
+        {
+            HrtDBJsonFile = new FileInfo(loadDir.FullName + "\\HrtGearDB.json");
+            if (!HrtDBJsonFile.Exists)
+                HrtDBJsonFile.Create().Close();
+            EtroDBJsonFile = new FileInfo(loadDir.FullName + "\\EtroGearDB.json");
+
+            if (!EtroDBJsonFile.Exists)
+                EtroDBJsonFile.Create().Close();
+            HrtGearDB = JsonConvert.DeserializeObject<Dictionary<string, GearSet>>(
+                reset ? "" : HrtDBJsonFile.OpenText().ReadToEnd(),
+                DataManager.JsonSerializerSettings) ?? new();
+            EtroGearDB = JsonConvert.DeserializeObject<Dictionary<string, GearSet>>(
+                reset ? "" : EtroDBJsonFile.OpenText().ReadToEnd(),
+                DataManager.JsonSerializerSettings) ?? new();
+        }
+        internal void AddOrGetSet(ref GearSet gearSet)
+        {
+            if (gearSet.ManagedBy == GearSetManager.HRT && gearSet.HrtID.Length > 0)
+            {
+                if (!HrtGearDB.ContainsKey(gearSet.HrtID))
+                    HrtGearDB.Add(gearSet.HrtID, gearSet);
+                if (HrtGearDB.TryGetValue(gearSet.HrtID, out GearSet? result))
+                {
+                    if (result.TimeStamp < gearSet.TimeStamp)
+                        result.CopyFrom(gearSet);
+                    gearSet = result;
+                }
+            }
+            else if (gearSet.ManagedBy == GearSetManager.Etro && gearSet.EtroID.Length > 0)
+            {
+                if (!EtroGearDB.ContainsKey(gearSet.EtroID))
+                    EtroGearDB.Add(gearSet.EtroID, gearSet);
+                if (EtroGearDB.TryGetValue(gearSet.EtroID, out GearSet? result))
+                    gearSet = result;
+            }
+        }
+
+        internal void Save()
+        {
+            File.WriteAllText(HrtDBJsonFile.FullName,
+                JsonConvert.SerializeObject(HrtGearDB, DataManager.JsonSerializerSettings));
+            File.WriteAllText(EtroDBJsonFile.FullName,
+                JsonConvert.SerializeObject(EtroGearDB, DataManager.JsonSerializerSettings));
+        }
+    }
+}

--- a/HimbeertoniRaidTool/DataManagement/GearSetReferenceConverter.cs
+++ b/HimbeertoniRaidTool/DataManagement/GearSetReferenceConverter.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using HimbeertoniRaidTool.Data;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace HimbeertoniRaidTool.DataManagement
+{
+    internal class GearSetReferenceConverter : JsonConverter<GearSet>
+
+    {
+        public override void WriteJson(JsonWriter writer, GearSet? value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            GearSetReference gsRef = new(value);
+            serializer.Serialize(writer, gsRef, typeof(GearSetReference));
+        }
+
+        public override GearSet? ReadJson(JsonReader reader, Type objectType, GearSet? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+            JObject jt = JObject.Load(reader);
+
+            GearSetReference? gsRef = jt.ContainsKey("ID") && jt.ContainsKey("ManagedBy") ? new((string?)jt["ID"] ?? "", (GearSetManager)(int)jt["ManagedBy"]) : null;
+            if (gsRef == null)
+                return null;
+            GearSet result = new()
+            {
+                ManagedBy = gsRef.ManagedBy,
+                HrtID = gsRef.ManagedBy == GearSetManager.HRT ? gsRef.ID : "",
+                EtroID = gsRef.ManagedBy == GearSetManager.Etro ? gsRef.ID : "",
+            };
+            DataManager.GearDB.AddOrGetSet(ref result);
+            return result;
+        }
+    }
+    public class GearSetReference
+    {
+        public string ID { get; set; }
+        public GearSetManager ManagedBy { get; set; }
+
+        public GearSetReference(GearSet set)
+        {
+            ManagedBy = set.ManagedBy;
+            if (set.ManagedBy == GearSetManager.HRT)
+                ID = set.HrtID;
+            else
+                ID = set.EtroID;
+        }
+
+        public GearSetReference(string id, GearSetManager gearSetManager)
+        {
+            ID = id;
+            ManagedBy = gearSetManager;
+        }
+    }
+}

--- a/HimbeertoniRaidTool/DataManagement/GearSetReferenceConverter.cs
+++ b/HimbeertoniRaidTool/DataManagement/GearSetReferenceConverter.cs
@@ -25,7 +25,7 @@ namespace HimbeertoniRaidTool.DataManagement
                 return null;
             JObject jt = JObject.Load(reader);
 
-            GearSetReference? gsRef = jt.ContainsKey("ID") && jt.ContainsKey("ManagedBy") ? new((string?)jt["ID"] ?? "", (GearSetManager)(int)jt["ManagedBy"]) : null;
+            GearSetReference? gsRef = jt.ContainsKey("ID") && jt.ContainsKey("ManagedBy") ? new((string)jt["ID"]!, (GearSetManager)(int)jt["ManagedBy"]!) : null;
             if (gsRef == null)
                 return null;
             GearSet result = new()

--- a/HimbeertoniRaidTool/HRTPlugin.cs
+++ b/HimbeertoniRaidTool/HRTPlugin.cs
@@ -64,6 +64,7 @@ namespace HimbeertoniRaidTool
             Loc.SetupWithLangCode(Services.PluginInterface.UiLanguage);
             Services.PluginInterface.LanguageChanged += OnLanguageChanged;
             InitCommands();
+            DataManagement.DataManager.Init();
             //Load and update/correct configuration + ConfigUi
             _Configuration = Services.PluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
             _Configuration.AfterLoad();
@@ -97,7 +98,7 @@ namespace HimbeertoniRaidTool
             Services.PluginInterface.LanguageChanged -= OnLanguageChanged;
             LootMaster.LootMaster.Dispose();
             Services.XivCommonBase.Dispose();
-            _Configuration.Save();
+            DataManagement.DataManager.Save();
         }
         private void OnCommand(string command, string args)
         {

--- a/HimbeertoniRaidTool/Helper.cs
+++ b/HimbeertoniRaidTool/Helper.cs
@@ -1,9 +1,11 @@
-﻿using ColorHelper;
+﻿using System;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+using ColorHelper;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using HimbeertoniRaidTool.Data;
 using Newtonsoft.Json;
-using System;
-using System.Numerics;
 
 namespace HimbeertoniRaidTool
 {
@@ -60,6 +62,12 @@ namespace HimbeertoniRaidTool
         {
             var serialized = JsonConvert.SerializeObject(source);
             return JsonConvert.DeserializeObject<T>(serialized)!;
+        }
+        public static int ConsistentHash(this string obj)
+        {
+            var alg = SHA512.Create();
+            var sha = alg.ComputeHash(Encoding.UTF8.GetBytes(obj));
+            return sha[0] + 256 * sha[1] + 256 * 256 * sha[2] + 256 * 256 * 256 * sha[2];
         }
     }
 

--- a/HimbeertoniRaidTool/LootMaster/GearRefresherOnExamine.cs
+++ b/HimbeertoniRaidTool/LootMaster/GearRefresherOnExamine.cs
@@ -76,7 +76,7 @@ namespace HimbeertoniRaidTool.LootMaster
             if (targetChar is null)
                 return;
             targetChar.GetClass(targetClass).Level = target.Level;
-            GearSet setToFill = new GearSet(GearSetManager.HRT, targetChar!, targetClass);
+            GearSet setToFill = new GearSet(GearSetManager.HRT, targetChar, targetClass);
             DataManagement.DataManager.GetManagedGearSet(ref setToFill);
 
             setToFill.Clear();

--- a/HimbeertoniRaidTool/LootMaster/LootMaster.cs
+++ b/HimbeertoniRaidTool/LootMaster/LootMaster.cs
@@ -1,12 +1,12 @@
-﻿using HimbeertoniRaidTool.Data;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using HimbeertoniRaidTool.Data;
 
 namespace HimbeertoniRaidTool.LootMaster
 {
     public static class LootMaster
     {
         internal static readonly LootmasterUI Ui = new();
-        internal static List<RaidGroup> RaidGroups => HRTPlugin.Configuration.RaidGroups;
+        internal static List<RaidGroup> RaidGroups => DataManagement.DataManager.Groups;
         internal static void Init()
         {
             if (RaidGroups.Count == 0)

--- a/HimbeertoniRaidTool/LootMaster/LootmasterUI.cs
+++ b/HimbeertoniRaidTool/LootMaster/LootmasterUI.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using ColorHelper;
 using Dalamud.Interface;
 using HimbeertoniRaidTool.Data;
+using HimbeertoniRaidTool.DataManagement;
 using HimbeertoniRaidTool.UI;
 using ImGuiNET;
 using static ColorHelper.HRTColorConversions;
@@ -338,6 +339,7 @@ namespace HimbeertoniRaidTool.LootMaster
                 ImGui.TableNextColumn();
                 ImGui.Text($"{player.Pos}  { player.NickName}");
                 ImGui.Text($"{ player.MainChar.Name} @ {player.MainChar.HomeWorld?.Name ?? "n.A."}");
+                Character c = player.MainChar;
 
                 if (player.MainChar.Classes.Count > 1)
                 {
@@ -382,7 +384,17 @@ namespace HimbeertoniRaidTool.LootMaster
                     DrawItem(gear.Ring2, bis.Ring2);
                 }
                 ImGui.TableNextColumn();
-                var playerChar = Helper.TryGetChar(player.MainChar.Name);
+                var playerChar = Helper.TryGetChar(player.MainChar.Name, player.MainChar.HomeWorld);
+                if (c.HomeWorldID == 0 && playerChar is null)
+                {
+                    playerChar = Helper.TryGetChar(player.MainChar.Name);
+                    if (playerChar is not null && !DataManager.CharacterExists(playerChar.HomeWorld.Id, player.MainChar.Name))
+                    {
+                        uint worldID = player.MainChar.HomeWorldID;
+                        player.MainChar.HomeWorldID = playerChar.HomeWorld.Id;
+                        DataManager.RearrangeCharacter(worldID, player.MainChar.Name, ref c);
+                    }
+                }
                 if (ImGuiHelper.Button(FontAwesomeIcon.Search, player.Pos.ToString(),
                     Localize("Inspect", "Update Gear"), playerChar is not null))
                 {

--- a/HimbeertoniRaidTool/LootMaster/LootmasterUI.cs
+++ b/HimbeertoniRaidTool/LootMaster/LootmasterUI.cs
@@ -354,6 +354,8 @@ namespace HimbeertoniRaidTool.LootMaster
                 GearSet bis = player.MainChar.MainClass.BIS;
                 ImGui.TableNextColumn();
                 ImGui.Text(gear.ItemLevel.ToString());
+                if (ImGui.IsItemHovered())
+                    ImGui.SetTooltip(gear.HrtID);
                 ImGui.Text($"{bis.ItemLevel - gear.ItemLevel} {Localize("to BIS", "to BIS")}");
                 ImGui.Text(bis.ItemLevel.ToString() + " (Link)");
                 if (ImGui.IsItemClicked())

--- a/HimbeertoniRaidTool/UI/EditWindows.cs
+++ b/HimbeertoniRaidTool/UI/EditWindows.cs
@@ -118,15 +118,17 @@ namespace HimbeertoniRaidTool.UI
                 PlayableClass target = Player.MainChar.GetClass(c.ClassType);
                 if (target.BIS.EtroID.Equals(c.BIS.EtroID))
                     continue;
-                target.BIS.EtroID = c.BIS.EtroID;
-                if (target.BIS.EtroID.Equals(""))
+                GearSet set = new()
                 {
-                    target.BIS.Clear();
-                }
-                else
+                    ManagedBy = GearSetManager.Etro,
+                    EtroID = c.BIS.EtroID
+                };
+                if (!set.EtroID.Equals(""))
                 {
+                    DataManagement.DataManager.GearDB.AddOrGetSet(ref set);
                     bisUpdates.Add((target.ClassType, () => EtroConnector.GetGearSet(target.BIS)));
                 }
+                target.BIS = set;
             }
             if (bisUpdates.Count > 0)
             {


### PR DESCRIPTION
GearSets now are stored by unique ID either provided by this plugin or etro
GearSets with same ID share cahnges troughout the Plugin
Chracters are likewise stored centrally identified by HomeWorld and Name
Characters can now be shared between raid groups

