### PR TITLE
Rework of loot rules

### DIFF
--- a/HimbeertoniRaidTool/Data/Enums.cs
+++ b/HimbeertoniRaidTool/Data/Enums.cs
@@ -41,9 +41,10 @@ namespace HimbeertoniRaidTool.Data
         BISOverUpgrade = 1,
         LowestItemLevel = 2,
         HighesItemLevelGain = 3,
-        ByPosition = 4,
+        RolePrio = 4,
         Random = 5,
-        Custom = 6,
+        DPS = 6,
+        Custom = 999,
     }
     public enum EncounterDifficulty
     {

--- a/HimbeertoniRaidTool/Data/Enums.cs
+++ b/HimbeertoniRaidTool/Data/Enums.cs
@@ -37,11 +37,13 @@ namespace HimbeertoniRaidTool.Data
     }
     public enum LootRuleEnum
     {
+        None = 0,
         BISOverUpgrade = 1,
         LowestItemLevel = 2,
         HighesItemLevelGain = 3,
         ByPosition = 4,
-        Random = 5
+        Random = 5,
+        Custom = 6,
     }
     public enum EncounterDifficulty
     {

--- a/HimbeertoniRaidTool/Data/GearSet.cs
+++ b/HimbeertoniRaidTool/Data/GearSet.cs
@@ -1,11 +1,13 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using Lumina.Excel.Extensions;
 using Newtonsoft.Json;
 
 namespace HimbeertoniRaidTool.Data
 {
     [JsonObject(MemberSerialization.OptIn, MissingMemberHandling = MissingMemberHandling.Ignore)]
-    public class GearSet
+    public class GearSet : IEnumerable<GearItem>
     {
         [JsonProperty("TimeStamp")]
         public DateTime? TimeStamp;
@@ -136,6 +138,16 @@ namespace HimbeertoniRaidTool.Data
 
             return result;
 
+        }
+
+        public IEnumerator<GearItem> GetEnumerator()
+        {
+            return ((IEnumerable<GearItem>)Items).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return Items.GetEnumerator();
         }
     }
 }

--- a/HimbeertoniRaidTool/Data/LootRuling.cs
+++ b/HimbeertoniRaidTool/Data/LootRuling.cs
@@ -49,11 +49,11 @@ namespace HimbeertoniRaidTool.Data
             LootRuleEnum.Random => DuplicateToString(x.Roll(session)),
             LootRuleEnum.LowestItemLevel => DuplicateToString(x.ItemLevel()),
             LootRuleEnum.HighesItemLevelGain => DuplicateToString(x.ItemLevelGain(x.ApplicableItem(currentPossibleLoot))),
-            LootRuleEnum.BISOverUpgrade => x.IsBiS(x.ApplicableItem(currentPossibleLoot)) ? (1, "y") : (-1, "n"),
+            LootRuleEnum.BISOverUpgrade => x.IsBiS(currentPossibleLoot) ? (1, "y") : (-1, "n"),
             LootRuleEnum.ByPosition => (x.RolePriority(session._group, session.RulingOptions.StrictRooling), x.MainChar.MainJob.GetRole().ToString()),
             _ => (0, "none")
         };
-        private (int, string) DuplicateToString(int val) => (val, $"{val}");
+        private static (int, string) DuplicateToString(int val) => (val, $"{val}");
         public override string ToString() => Name;
         private string GetName() => Rule switch
         {
@@ -96,7 +96,7 @@ namespace HimbeertoniRaidTool.Data
         public static int Roll(this Player p, LootSession session) => session.Rolls[p];
         public static int ItemLevel(this Player p) => p.Gear.ItemLevel;
         public static int ItemLevelGain(this Player p, GearItem? newItem) => newItem == null ? 0 : (int)newItem.ItemLevel - (int)p.Gear[newItem.Slot].ItemLevel;
-        public static bool IsBiS(this Player p, GearItem? newItem) => newItem != null && p.BIS.Contains(newItem);
+        public static bool IsBiS(this Player p, List<GearItem> items) => p.BIS.Any(bisItem => items.Any(i => i.ID == bisItem.ID));
         public static GearItem? ApplicableItem(this Player p, List<GearItem> possibleItems)
         {
             if (!possibleItems.Any(i => i.Item?.ClassJobCategory.Value.Contains(p.MainChar.MainJob) ?? false))

--- a/HimbeertoniRaidTool/Data/LootRuling.cs
+++ b/HimbeertoniRaidTool/Data/LootRuling.cs
@@ -17,14 +17,19 @@ namespace HimbeertoniRaidTool.Data
             {
                 List<LootRule> result = new();
                 foreach (LootRuleEnum rule in Enum.GetValues(typeof(LootRuleEnum)))
+                {
+                    if (rule == LootRuleEnum.None)
+                        continue;
+                    //Not yet functional
+                    if (rule == LootRuleEnum.Custom)
+                        continue;
                     result.Add(new(rule));
+                }
                 return result;
             }
         }
         [JsonProperty("RuleSet")]
         public List<LootRule> RuleSet = new();
-        [JsonProperty("StrictRooling")]
-        public bool StrictRooling = false;
     }
 
 
@@ -50,7 +55,7 @@ namespace HimbeertoniRaidTool.Data
             LootRuleEnum.LowestItemLevel => DuplicateToString(x.ItemLevel()),
             LootRuleEnum.HighesItemLevelGain => DuplicateToString(x.ItemLevelGain(x.ApplicableItem(currentPossibleLoot))),
             LootRuleEnum.BISOverUpgrade => x.IsBiS(currentPossibleLoot) ? (1, "y") : (-1, "n"),
-            LootRuleEnum.ByPosition => (x.RolePriority(session._group, session.RulingOptions.StrictRooling), x.MainChar.MainJob.GetRole().ToString()),
+            LootRuleEnum.ByPosition => (x.RolePriority(session._group), x.MainChar.MainJob.GetRole().ToString()),
             _ => (0, "none")
         };
         private static (int, string) DuplicateToString(int val) => (val, $"{val}");
@@ -103,13 +108,13 @@ namespace HimbeertoniRaidTool.Data
                 return null;
             return possibleItems.First(i => i.Item?.ClassJobCategory.Value.Contains(p.MainChar.MainJob) ?? false);
         }
-        public static int RolePriority(this Player p, RaidGroup g, bool strict) => p.MainChar.MainJob.GetRole() switch
+        public static int RolePriority(this Player p, RaidGroup g) => p.MainChar.MainJob.GetRole() switch
         {
-            Role.Melee => strict ? 0 : 0,
-            Role.Caster => strict ? 2 : 2,
-            Role.Ranged => strict ? 3 : 2,
-            Role.Tank => strict ? 4 : 4,
-            Role.Healer => strict ? 6 : 6,
+            Role.Melee => 0,
+            Role.Caster => 2,
+            Role.Ranged => 2,
+            Role.Tank => 4,
+            Role.Healer => 6,
             _ => 8
         };
     }

--- a/HimbeertoniRaidTool/Data/Player.cs
+++ b/HimbeertoniRaidTool/Data/Player.cs
@@ -11,6 +11,8 @@ namespace HimbeertoniRaidTool.Data
         public string NickName = "";
         [JsonProperty("Pos")]
         public PositionInRaidGroup Pos;
+        [JsonProperty("AdditionalData", ObjectCreationHandling = ObjectCreationHandling.Replace)]
+        public readonly AdditionalPlayerData AdditionalData = new();
         [JsonProperty("Chars")]
         public List<Character> Chars { get; set; } = new();
         public bool Filled => NickName != "";
@@ -46,5 +48,22 @@ namespace HimbeertoniRaidTool.Data
         }
 
 
+    }
+    [JsonObject(MemberSerialization.OptIn)]
+    public class AdditionalPlayerData
+    {
+        private const string ManualDPSKey = "ManualDPS";
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
+        public Dictionary<string, int> IntData = new();
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
+        public Dictionary<string, float> FloatData = new();
+        [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
+        public Dictionary<string, string> StringData = new();
+
+        public int ManualDPS
+        {
+            get { return IntData.GetValueOrDefault(ManualDPSKey, 0); }
+            set { IntData[ManualDPSKey] = value; }
+        }
     }
 }

--- a/HimbeertoniRaidTool/Data/RaidGroup.cs
+++ b/HimbeertoniRaidTool/Data/RaidGroup.cs
@@ -13,6 +13,8 @@ namespace HimbeertoniRaidTool.Data
         private readonly Player[] _Players;
         [JsonProperty("Type")]
         public GroupType Type;
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public RolePriority? RolePriority = null;
         [JsonProperty]
         public Player Tank1 { get => _Players[0]; set => _Players[0] = value; }
         [JsonProperty]

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootMasterConfiguration.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootMasterConfiguration.cs
@@ -159,7 +159,7 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                 RuleSet = new List<LootRule>()
                         {
                             new(LootRuleEnum.BISOverUpgrade),
-                            new(LootRuleEnum.ByPosition),
+                            new(LootRuleEnum.RolePrio),
                             new(LootRuleEnum.HighesItemLevelGain),
                             new(LootRuleEnum.LowestItemLevel),
                             new(LootRuleEnum.Random)

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootMasterConfiguration.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootMasterConfiguration.cs
@@ -118,7 +118,12 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                 }
                 if (ImGui.BeginTabItem("Loot"))
                 {
+                    ImGui.Text(Localize("LootRuleOrder", "Order in which loot rules should be applied"));
                     LootList.Draw();
+                    ImGui.Separator();
+                    ImGui.Text(Localize("ConfigRolePriority", "Priority to loot for each role (smaller is higher priority)"));
+                    ImGui.Text($"{Localize("Current priority", "Current priority")}: {_dataCopy.RolePriority}");
+                    _dataCopy.RolePriority.DrawEdit();
                     ImGui.EndTabItem();
                 }
                 ImGui.EndTabBar();
@@ -160,6 +165,14 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                             new(LootRuleEnum.Random)
                         }
             };
+            [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
+            public RolePriority RolePriority = new()
+            {
+                { Role.Melee,   0 },
+                { Role.Caster,  1 },
+                { Role.Ranged,  1 },
+                { Role.Tank,    3 },
+                { Role.Healer,  4 },
             };
             [JsonProperty]
             public bool OpenOnStartup = false;

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootMasterConfiguration.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootMasterConfiguration.cs
@@ -118,7 +118,6 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                 }
                 if (ImGui.BeginTabItem("Loot"))
                 {
-                    ImGui.Checkbox(Localize("Strict Ruling", "Strict Ruling"), ref _dataCopy.LootRuling.StrictRooling);
                     LootList.Draw();
                     ImGui.EndTabItem();
                 }
@@ -159,8 +158,8 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                             new(LootRuleEnum.HighesItemLevelGain),
                             new(LootRuleEnum.LowestItemLevel),
                             new(LootRuleEnum.Random)
-                        },
-                StrictRooling = true
+                        }
+            };
             };
             [JsonProperty]
             public bool OpenOnStartup = false;

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootSession.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootSession.cs
@@ -13,7 +13,7 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
         public Dictionary<Player, int> Rolls;
         public LootRuling RulingOptions { get; private set; }
         internal readonly (HrtItem, int)[] Loot;
-        private readonly RaidGroup _group;
+        internal readonly RaidGroup _group;
         public Dictionary<(HrtItem, int), List<(Player, string)>> Results;
         public List<Player> Excluded = new();
         private int NumLootItems => Loot.Aggregate(0, (sum, x) => sum + x.Item2);
@@ -32,17 +32,17 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
             if (Results.Count == NumLootItems && !reevaluate)
                 return;
             Results.Clear();
-            foreach (var item in Loot)
-                for (int i = 0; i < item.Item2; i++)
+            foreach ((HrtItem item, int count) singleLoot in Loot)
+                for (int i = 0; i < singleLoot.count; i++)
                 {
-                    if (item.Item1.IsExhangableItem)
-                        Results.Add((item.Item1, i), Evaluate(new ExchangableItem(item.Item1.ID).PossiblePurchases, Excluded));
-                    else if (item.Item1.IsContainerItem)
-                        Results.Add((item.Item1, i), Evaluate(new ContainerItem(item.Item1.ID).PossiblePurchases, Excluded));
-                    else if (item.Item1.IsGear)
-                        Results.Add((item.Item1, i), Evaluate(new List<GearItem> { new(item.Item1.ID) }, Excluded));
+                    if (singleLoot.item.IsExhangableItem)
+                        Results.Add((singleLoot.item, i), Evaluate(new ExchangableItem(singleLoot.item.ID).PossiblePurchases, Excluded));
+                    else if (singleLoot.item.IsContainerItem)
+                        Results.Add((singleLoot.item, i), Evaluate(new ContainerItem(singleLoot.item.ID).PossiblePurchases, Excluded));
+                    else if (singleLoot.item.IsGear)
+                        Results.Add((singleLoot.item, i), Evaluate(new List<GearItem> { new(singleLoot.item.ID) }, Excluded));
                     else
-                        Results.Add((item.Item1, i), new());
+                        Results.Add((singleLoot.item, i), new());
                 }
         }
         private List<(Player, string)> Evaluate(List<GearItem> possibleItems, List<Player> excludeAddition)
@@ -71,7 +71,7 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
             for (int i = 0; i < need.Count - 1; i++)
             {
                 result.Add((need[i],
-                    comparer.RulingReason.GetValueOrDefault((need[i], need[i + 1]), new()).ToString()));
+                    comparer.RulingReason.TryGetValue((need[i], need[i + 1]), out var reasoning) ? $"{reasoning.rule} ({reasoning.valueL} over {reasoning.valueR})" : "None"));
             }
             if (need.Count > 0)
                 result.Add((need[^1], Localize("Need > Greed", "Need > Greed")));
@@ -86,7 +86,7 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
         {
             private readonly LootSession _session;
             private readonly List<GearItem> _possibleItems;
-            public Dictionary<(Player, Player), LootRule> RulingReason = new();
+            public Dictionary<(Player, Player), (LootRule rule, int result, string valueL, string valueR)> RulingReason = new();
             public LootRulingComparer(LootSession session, List<GearItem> possibleItems)
                 => (_session, _possibleItems) = (session, possibleItems);
 
@@ -95,18 +95,18 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                 if (x is null || y is null)
                     return 0;
                 if (RulingReason.ContainsKey((x, y)))
-                    return RulingReason[(x, y)].Compare(x, y, _session, _possibleItems);
+                    return RulingReason[(x, y)].result;
                 foreach (var rule in _session.RulingOptions.RuleSet)
                 {
-                    int result = rule.Compare(x, y, _session, _possibleItems);
+                    (int result, string forX, string forY) = rule.Compare(x, y, _session, _possibleItems);
                     if (result != 0)
                     {
-                        RulingReason.Add((x, y), rule);
-                        RulingReason.Add((y, x), rule);
+                        RulingReason.Add((x, y), (rule, result, forX, forY));
+                        RulingReason.Add((y, x), (rule, -result, forY, forX));
                         return result;
                     }
                 }
-                RulingReason.Add((x, y), new());
+                RulingReason.Add((x, y), (new(LootRuleEnum.None), 0, string.Empty, string.Empty));
                 return 0;
             }
         }

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootSession.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootSession.cs
@@ -16,12 +16,14 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
         internal readonly RaidGroup _group;
         public Dictionary<(HrtItem, int), List<(Player, string)>> Results;
         public List<Player> Excluded = new();
+        public readonly RolePriority RolePriority;
         private int NumLootItems => Loot.Aggregate(0, (sum, x) => sum + x.count);
-        public LootSession(RaidGroup group, LootRuling rulingOptions, (HrtItem, int)[] items)
+        public LootSession(RaidGroup group, LootRuling rulingOptions, RolePriority rolePriority, (HrtItem, int)[] items)
         {
             RulingOptions = rulingOptions.Clone();
             Loot = items;
             _group = group;
+            RolePriority = rolePriority;
             Rolls = new();
             foreach (var p in _group.Players)
                 Rolls.Add(p, Random.Next(0, 101));

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootSession.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootSession.cs
@@ -12,11 +12,11 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
         private readonly Random Random = new(Guid.NewGuid().GetHashCode());
         public Dictionary<Player, int> Rolls;
         public LootRuling RulingOptions { get; private set; }
-        internal readonly (HrtItem, int)[] Loot;
+        internal readonly (HrtItem item, int count)[] Loot;
         internal readonly RaidGroup _group;
         public Dictionary<(HrtItem, int), List<(Player, string)>> Results;
         public List<Player> Excluded = new();
-        private int NumLootItems => Loot.Aggregate(0, (sum, x) => sum + x.Item2);
+        private int NumLootItems => Loot.Aggregate(0, (sum, x) => sum + x.count);
         public LootSession(RaidGroup group, LootRuling rulingOptions, (HrtItem, int)[] items)
         {
             RulingOptions = rulingOptions.Clone();
@@ -32,17 +32,17 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
             if (Results.Count == NumLootItems && !reevaluate)
                 return;
             Results.Clear();
-            foreach ((HrtItem item, int count) singleLoot in Loot)
-                for (int i = 0; i < singleLoot.count; i++)
+            foreach ((HrtItem item, int count) in Loot)
+                for (int i = 0; i < count; i++)
                 {
-                    if (singleLoot.item.IsExhangableItem)
-                        Results.Add((singleLoot.item, i), Evaluate(new ExchangableItem(singleLoot.item.ID).PossiblePurchases, Excluded));
-                    else if (singleLoot.item.IsContainerItem)
-                        Results.Add((singleLoot.item, i), Evaluate(new ContainerItem(singleLoot.item.ID).PossiblePurchases, Excluded));
-                    else if (singleLoot.item.IsGear)
-                        Results.Add((singleLoot.item, i), Evaluate(new List<GearItem> { new(singleLoot.item.ID) }, Excluded));
+                    if (item.IsExhangableItem)
+                        Results.Add((item, i), Evaluate(new ExchangableItem(item.ID).PossiblePurchases, Excluded));
+                    else if (item.IsContainerItem)
+                        Results.Add((item, i), Evaluate(new ContainerItem(item.ID).PossiblePurchases, Excluded));
+                    else if (item.IsGear)
+                        Results.Add((item, i), Evaluate(new List<GearItem> { new(item.ID) }, Excluded));
                     else
-                        Results.Add((singleLoot.item, i), new());
+                        Results.Add((item, i), new());
                 }
         }
         private List<(Player, string)> Evaluate(List<GearItem> possibleItems, List<Player> excludeAddition)

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootSessionUI.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootSessionUI.cs
@@ -90,13 +90,12 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                     if (ImGui.BeginTabItem($"{result.Key.Item1.Name} # {result.Key.Item2 + 1}"))
                     {
                         ImGui.Text(string.Format(Localize("LootRuleHeader", "Loot Results for {0}: "), result.Key.Item1.Name));
-                        if (ImGui.BeginTable($"LootTable##{result.Key.Item1.Name} # {result.Key.Item2 + 1}", 4,
+                        if (ImGui.BeginTable($"LootTable##{result.Key.Item1.Name} # {result.Key.Item2 + 1}", 3,
                             ImGuiTableFlags.Borders | ImGuiTableFlags.SizingStretchProp))
                         {
                             ImGui.TableSetupColumn(Localize("Pos", "Pos"));
                             ImGui.TableSetupColumn(Localize("Player", "Player"));
                             ImGui.TableSetupColumn(Localize("Rule", "Rule"));
-                            ImGui.TableSetupColumn(Localize("Roll", "Roll"));
                             ImGui.TableHeadersRow();
 
                             int place = 1;
@@ -108,8 +107,6 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                                 ImGui.Text($"{looter.Player.NickName} ({looter.Player.MainChar.MainJob})");
                                 ImGui.TableNextColumn();
                                 ImGui.Text(looter.Reason);
-                                ImGui.TableNextColumn();
-                                ImGui.Text(_session.Rolls[looter.Player].ToString());
 
                                 //ImGui.Text($"{place}: {looter.Player.NickName} Rule: { looter.Reason} Roll: {_session.Rolls[looter.Player]}");
                                 place++;

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootSessionUI.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootSessionUI.cs
@@ -53,10 +53,10 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
 
             if (ImGui.BeginChild("Rules", new Vector2(270, 270), false))
             {
-                ImGui.TextWrapped($"Role priority:\n{_session.RolePriority}");
+                ImGui.TextWrapped($"{Localize("Role priority", "Role priority")}:\n{_session.RolePriority}");
                 _ruleListUi.Draw();
                 if (ImGuiHelper.Button(Localize("Reset to default", "Reset to default"),
-                    Localize("Overrides these settings with defaults from configuration", "Overrides these settings with defaults from configuration")))
+                    Localize("OverrideWithDefaults", "Overrides these settings with defaults from configuration")))
                 {
                     _ruleListUi = new(LootRuling.PossibleRules, _lootRuling.RuleSet);
                 }
@@ -75,16 +75,15 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                 _session = session;
                 Size = new Vector2(450, 310);
                 Title = Localize("LootResultTitle", "Loot Results");
-                WindowFlags = ImGuiWindowFlags.NoResize;
+                WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
             }
             protected override void Draw()
             {
-                ImGui.BeginTabBar("Items", ImGuiTabBarFlags.FittingPolicyScroll);
                 foreach (((HrtItem item, int nr), List<(Player player, string reason)> ruling) in _session.Results)
                 {
-                    if (ImGui.BeginTabItem($"{item.Name} # {nr + 1}"))
+                    if (ImGui.CollapsingHeader($"{item.Name} # {nr + 1}\n {ruling[0].player.NickName} won" +
+                        $"{(ruling.Count > 1 ? $" over {ruling[1].player.NickName} ({ruling[0].reason})" : "")}"))
                     {
-                        ImGui.Text(string.Format(Localize("LootRuleHeader", "Loot Results for {0}: "), item.Name));
                         if (ImGui.BeginTable($"LootTable##{item.Name} # {nr + 1}", 3,
                             ImGuiTableFlags.Borders | ImGuiTableFlags.SizingStretchProp))
                         {
@@ -106,10 +105,8 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                             }
                             ImGui.EndTable();
                         }
-                        ImGui.EndTabItem();
                     }
                 }
-                ImGui.EndTabBar();
             }
         }
     }

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootSessionUI.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootSessionUI.cs
@@ -56,9 +56,7 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
                     Localize("Overrides these settings with defaults from configuration", "Overrides these settings with defaults from configuration")))
                 {
                     _ruleListUi = new(LootRuling.PossibleRules, _lootRuling.RuleSet);
-                    _session.RulingOptions.StrictRooling = _lootRuling.StrictRooling;
                 }
-                ImGui.Checkbox(Localize("Strict Ruling", "Strict Ruling"), ref _session.RulingOptions.StrictRooling);
                 _ruleListUi.Draw();
                 ImGui.NewLine();
 

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootmasterUI.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootmasterUI.cs
@@ -523,7 +523,7 @@ namespace HimbeertoniRaidTool.Modules.LootMaster
             {
                 if (ImGuiHelper.Button(lootSource.ToString(), null))
                 {
-                    LootSessionUI lui = new(lootSource, CurrentGroup, _lootMaster.Configuration.Data.LootRuling);
+                    LootSessionUI lui = new(lootSource, CurrentGroup, _lootMaster.Configuration.Data.LootRuling, _lootMaster.Configuration.Data.RolePriority);
                     lui.Show();
                 }
                 ImGui.SameLine();

--- a/HimbeertoniRaidTool/UI/EditWindows.cs
+++ b/HimbeertoniRaidTool/UI/EditWindows.cs
@@ -46,7 +46,7 @@ namespace HimbeertoniRaidTool.UI
             {
                 PlayerCopy = Player.Clone();
             }
-            (Size, SizingCondition) = (new Vector2(450, 300 + (ClassHeight * PlayerCopy.MainChar.Classes.Count)), ImGuiCond.Appearing);
+            (Size, SizingCondition) = (new Vector2(450, 330 + (ClassHeight * PlayerCopy.MainChar.Classes.Count)), ImGuiCond.Appearing);
             Title = $"{Localize("Edit Player", "Edit Player")} {Player.NickName} ({RaidGroup.Name})##{Player.Pos}";
         }
         protected override void Draw()
@@ -56,6 +56,9 @@ namespace HimbeertoniRaidTool.UI
             ImGui.SetCursorPosX((ImGui.GetWindowWidth() - ImGui.CalcTextSize(Localize("Player Data", "Player Data")).X) / 2f);
             ImGui.Text(Localize("Player Data", "Player Data"));
             ImGui.InputText(Localize("Player Name", "Player Name"), ref PlayerCopy.NickName, 50);
+            int dps = PlayerCopy.AdditionalData.ManualDPS;
+            if (ImGui.InputInt(Localize("manuallySetDPS", "Predicted DPS"), ref dps, 100, 1000))
+                PlayerCopy.AdditionalData.ManualDPS = dps;
             //Character Data
             ImGui.SetCursorPosX((ImGui.GetWindowWidth() - ImGui.CalcTextSize(Localize("Character Data", "Character Data")).X) / 2f);
             ImGui.Text(Localize("Character Data", "Character Data"));
@@ -169,6 +172,7 @@ namespace HimbeertoniRaidTool.UI
         {
             List<(Job, Func<bool>)> bisUpdates = new();
             Player.NickName = PlayerCopy.NickName;
+            Player.AdditionalData.ManualDPS = PlayerCopy.AdditionalData.ManualDPS;
             if (IsNew)
             {
                 Character c = new Character(PlayerCopy.MainChar.Name, PlayerCopy.MainChar.HomeWorldID);

--- a/HimbeertoniRaidTool/UI/EditWindows.cs
+++ b/HimbeertoniRaidTool/UI/EditWindows.cs
@@ -234,7 +234,7 @@ namespace HimbeertoniRaidTool.UI
             OnCancel = onCancel ?? (() => { });
             GroupCopy = Group.Clone();
             Show();
-            (Size, SizingCondition) = (new Vector2(500, 250), ImGuiCond.Appearing);
+            (Size, SizingCondition) = (new Vector2(500, 150 + (group.RolePriority != null ? 180 : 0)), ImGuiCond.Appearing);
             Title = Localize("Edit Group ", "Edit Group ") + Group.Name;
         }
 
@@ -246,10 +246,24 @@ namespace HimbeertoniRaidTool.UI
             {
                 GroupCopy.Type = (GroupType)groupType;
             }
+            bool overrrideRolePriority = GroupCopy.RolePriority != null;
+            if (ImGui.Checkbox(Localize("Overrride role priority", "Overrride role priority"), ref overrrideRolePriority))
+            {
+                GroupCopy.RolePriority = overrrideRolePriority ? new RolePriority() : null;
+                Size.Y += (overrrideRolePriority ? 1 : -1) * 180f;
+            }
+            if (overrrideRolePriority)
+            {
+                ImGui.Text(Localize("ConfigRolePriority", "Priority to loot for each role (smaller is higher priority)"));
+                ImGui.Text($"{Localize("Current priority", "Current priority")}: {GroupCopy.RolePriority}");
+                GroupCopy.RolePriority!.DrawEdit();
+            }
+
             if (ImGuiHelper.SaveButton())
             {
                 Group.Name = GroupCopy.Name;
                 Group.Type = GroupCopy.Type;
+                Group.RolePriority = GroupCopy.RolePriority;
                 OnSave();
                 Hide();
             }

--- a/UnitTestsData/UiTests.cs
+++ b/UnitTestsData/UiTests.cs
@@ -1,7 +1,7 @@
-using Xunit;
+﻿using System.Collections.Generic;
 using HimbeertoniRaidTool.Data;
 using HimbeertoniRaidTool.UI;
-using System.Collections.Generic;
+using Xunit;
 
 namespace UnitTestsData
 {
@@ -10,15 +10,14 @@ namespace UnitTestsData
         [Fact]
         public void TestUiSortableList()
         {
-
             List<string> P = new() { "a", "b", "c", "d", "e" };
-            List<string> L = new() { "c", "d", "a"};
-            UiSortableList<string> sortableList = new(P,L);
+            List<string> L = new() { "c", "d", "a" };
+            UiSortableList<string> sortableList = new(P, L);
             Assert.Equal(L, sortableList.List);
             List<LootRule> RuleSet = new()
             {
                 new(LootRuleEnum.BISOverUpgrade),
-                new(LootRuleEnum.ByPosition),
+                new(LootRuleEnum.RolePrio),
                 new(LootRuleEnum.HighesItemLevelGain),
                 new(LootRuleEnum.LowestItemLevel),
                 new(LootRuleEnum.Random)
@@ -31,11 +30,11 @@ namespace UnitTestsData
             Assert.Equal(RuleSet, LootRuling.RuleSet);
             List<LootRule> P2 = LootRuling.PossibleRules;
             List<LootRule> L2 = LootRuling.RuleSet;
-            
+
             UiSortableList<LootRule> sortableList2 = new(P2, L2);
             Assert.Equal(5, sortableList2.List.Count);
             Assert.Equal(5, L2.Count);
-            for(int i = 0; i < L2.Count; i++)
+            for (int i = 0; i < L2.Count; i++)
                 Assert.Equal(L2[i], sortableList2.List[i]);
         }
     }


### PR DESCRIPTION
- role priority can be edited (global and per group)
- result table includes compared values for rule
- remove strict ruling
- add posibilty to prioritise by dps (curated manually)
- made Ui clearer