### PR TITLE
Added command conflict resolution

### DIFF
--- a/HimbeertoniRaidTool/HRTPlugin.cs
+++ b/HimbeertoniRaidTool/HRTPlugin.cs
@@ -120,13 +120,18 @@ public sealed class HRTPlugin : IDalamudPlugin
 
     private void AddCommand(HrtCommand command)
     {
-        if (ServiceManager.CommandManager.AddHandler(command.Command,
-            new CommandInfo((x, y) => command.OnCommand(y))
-            {
-                HelpMessage = command.Description,
-                ShowInHelp = command.ShowInHelp
-            }))
+        CommandInfo commandInfo = new CommandInfo((x, y) => command.OnCommand(y))
+        {
+            HelpMessage = command.Description,
+            ShowInHelp = command.ShowInHelp
+        };
+        if (ServiceManager.CommandManager.AddHandler(command.Command, commandInfo))
         { RegisteredCommands.Add(command.Command); }
+        else {
+            commandInfo.HelpMessage = commandInfo.HelpMessage.Replace("/lm", "/hrtlm");
+            if (ServiceManager.CommandManager.AddHandler(command.getCommandBackup(command.Command), commandInfo))
+            { RegisteredCommands.Add(command.getCommandBackup(command.Command)); }
+        }
     }
     public void Dispose()
     {

--- a/HimbeertoniRaidTool/Modules/HrtModule.cs
+++ b/HimbeertoniRaidTool/Modules/HrtModule.cs
@@ -1,5 +1,7 @@
 ﻿using Dalamud.Game;
 using Dalamud.Interface.Windowing;
+using Dalamud.Logging;
+
 using HimbeertoniRaidTool.Plugin.UI;
 
 namespace HimbeertoniRaidTool.Plugin.Modules;
@@ -29,4 +31,7 @@ public struct HrtCommand
     internal string Description;
     internal bool ShowInHelp;
     internal Action<string> OnCommand;
+    internal string getCommandBackup(string command) {
+        return command.Replace("/", "/hrt");
+    }
 }


### PR DESCRIPTION
When having plugins such as LMeter installed and LootMaster, the commands `/lm` and `/lootmaster` error and say that they are already registered. I have implemented a way for the plugin to register these commands by prepending `hrt` to the command name after the slash.

The commands transform as such:
```
/lm         => /hrtlm
/lootmaster => /hrtlootmaster
```