### PR TITLE
Make all commands available as first argument to /hrt

### DIFF
--- a/HimbeertoniRaidTool/Modules/HrtModule.cs
+++ b/HimbeertoniRaidTool/Modules/HrtModule.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game;
+using Dalamud.Game.Command;
 using Dalamud.Interface.Windowing;
 using HimbeertoniRaidTool.Plugin.UI;
 
@@ -28,5 +29,6 @@ public struct HrtCommand
     internal string Command;
     internal string Description;
     internal bool ShowInHelp;
-    internal Action<string> OnCommand;
+    internal CommandInfo.HandlerDelegate OnCommand;
+    internal bool ShouldExposeToDalamud;
 }

--- a/HimbeertoniRaidTool/Modules/LootMaster/LootMasterModule.cs
+++ b/HimbeertoniRaidTool/Modules/LootMaster/LootMasterModule.cs
@@ -26,6 +26,7 @@ internal sealed class LootMasterModule : IHrtModule<LootMasterConfiguration.Conf
             Description = Localize("/lootmaster", "Opens LootMaster Window (or /lm as short variant)"),
             ShowInHelp = true,
             OnCommand = OnCommand,
+            ShouldExposeToDalamud = true,
         },
         new()
         {
@@ -33,6 +34,7 @@ internal sealed class LootMasterModule : IHrtModule<LootMasterConfiguration.Conf
             Description = Localize("/lootmaster", "Opens LootMaster Window (or /lm as short variant)"),
             ShowInHelp = false,
             OnCommand = OnCommand,
+            ShouldExposeToDalamud = true,
         }
     };
     //Properties
@@ -249,7 +251,7 @@ internal sealed class LootMasterModule : IHrtModule<LootMasterConfiguration.Conf
         }
         ServiceManager.HrtDataManager.Save();
     }
-    public void OnCommand(string args)
+    public void OnCommand(string command, string args)
     {
         switch (args)
         {


### PR DESCRIPTION
Allows usage of commands in this manner:  /lm as /hrt lm